### PR TITLE
Add schemas for inventory management

### DIFF
--- a/psql_schemas/deploy/computers.sql
+++ b/psql_schemas/deploy/computers.sql
@@ -1,0 +1,13 @@
+-- Deploy meatPacker:computers to pg
+
+BEGIN;
+
+create table computers (
+      computer_id bigserial primary key
+    , os text null
+    , motherboard_model text not null
+    , motherboard_sn text null
+    , barcode bigint unique
+);
+
+COMMIT;

--- a/psql_schemas/deploy/cpus.sql
+++ b/psql_schemas/deploy/cpus.sql
@@ -1,0 +1,16 @@
+-- Deploy meatPacker:cpus to pg
+-- requires: cycle_units
+-- requires: computers
+
+BEGIN;
+
+create table cpus (
+      computer_id bigint references computers
+    , model text not null
+    , core_count int not null
+    , threads_per_core int not null
+    , speed bigint not null
+    , speed_unit cycle_units not null
+);
+
+COMMIT;

--- a/psql_schemas/deploy/cycle_units.sql
+++ b/psql_schemas/deploy/cycle_units.sql
@@ -1,0 +1,14 @@
+-- Deploy meatPacker:cycle_units to pg
+
+BEGIN;
+
+create type cycle_units as enum (
+      'Hz'
+    , 'KHz'
+    , 'MHz'
+    , 'GHz'
+    , 'THz'
+    , 'PHz'
+);
+
+COMMIT;

--- a/psql_schemas/deploy/drives.sql
+++ b/psql_schemas/deploy/drives.sql
@@ -1,0 +1,23 @@
+-- Deploy meatPacker:drives to pg
+-- requires: size_units
+-- requires: computers
+
+BEGIN;
+
+create type drive_types as enum (
+      'HDD'
+    , 'SSD'
+    , 'NVME'
+);
+
+create table drives (
+      computer_id bigint references computers
+    , model text not null
+    , drive_size text not null
+    , size_unit size_units not null
+    , rpm int null
+    , drive_type drive_types not null
+    , sn text not null
+);
+
+COMMIT;

--- a/psql_schemas/deploy/memory.sql
+++ b/psql_schemas/deploy/memory.sql
@@ -1,0 +1,25 @@
+-- Deploy meatPacker:memory to pg
+-- requires: size_units
+-- requires: transfer_units
+-- requires: computers
+
+BEGIN;
+
+create type memory_types as enum (
+      'DDR'
+    , 'DDR2'
+    , 'DDR3'
+    , 'DDR4'
+);
+
+create table memory (
+      computer_id bigint references computers
+    , model text null
+    , mem_speed bigint not null
+    , speed_unit transfer_units not null
+    , mem_size bigint not null
+    , size_unit size_units not null
+    , mem_type memory_types not null
+);
+
+COMMIT;

--- a/psql_schemas/deploy/size_units.sql
+++ b/psql_schemas/deploy/size_units.sql
@@ -1,0 +1,14 @@
+-- Deploy meatPacker:size_units to pg
+
+BEGIN;
+
+create type size_units as enum (
+      'B'
+    , 'KB'
+    , 'MB'
+    , 'GB'
+    , 'TB'
+    , 'PB'
+);
+
+COMMIT;

--- a/psql_schemas/deploy/transfer_units.sql
+++ b/psql_schemas/deploy/transfer_units.sql
@@ -1,0 +1,14 @@
+-- Deploy meatPacker:transfer_units to pg
+
+BEGIN;
+
+create type transfer_units as enum (
+      'T/s'
+    , 'KT/s'
+    , 'MT/s'
+    , 'GT/s'
+    , 'TT/s'
+    , 'PT/s'
+);
+
+COMMIT;

--- a/psql_schemas/revert/computers.sql
+++ b/psql_schemas/revert/computers.sql
@@ -1,0 +1,7 @@
+-- Revert meatPacker:computers from pg
+
+BEGIN;
+
+drop table computers;
+
+COMMIT;

--- a/psql_schemas/revert/cpus.sql
+++ b/psql_schemas/revert/cpus.sql
@@ -1,0 +1,7 @@
+-- Revert meatPacker:cpus from pg
+
+BEGIN;
+
+drop table cpus;
+
+COMMIT;

--- a/psql_schemas/revert/cycle_units.sql
+++ b/psql_schemas/revert/cycle_units.sql
@@ -1,0 +1,7 @@
+-- Revert meatPacker:cycle_units from pg
+
+BEGIN;
+
+drop type cycle_units;
+
+COMMIT;

--- a/psql_schemas/revert/drives.sql
+++ b/psql_schemas/revert/drives.sql
@@ -1,0 +1,9 @@
+-- Revert meatPacker:drives from pg
+
+BEGIN;
+
+drop table drives;
+
+drop type drive_types;
+
+COMMIT;

--- a/psql_schemas/revert/memory.sql
+++ b/psql_schemas/revert/memory.sql
@@ -1,0 +1,9 @@
+-- Revert meatPacker:memory from pg
+
+BEGIN;
+
+drop table memory;
+
+drop type memory_types;
+
+COMMIT;

--- a/psql_schemas/revert/size_units.sql
+++ b/psql_schemas/revert/size_units.sql
@@ -1,0 +1,7 @@
+-- Revert meatPacker:size_units from pg
+
+BEGIN;
+
+drop type size_units;
+
+COMMIT;

--- a/psql_schemas/revert/transfer_units.sql
+++ b/psql_schemas/revert/transfer_units.sql
@@ -1,0 +1,7 @@
+-- Revert meatPacker:transfer_units from pg
+
+BEGIN;
+
+drop type transfer_units;
+
+COMMIT;

--- a/psql_schemas/sqitch.conf
+++ b/psql_schemas/sqitch.conf
@@ -1,0 +1,4 @@
+ [core]
+	 engine = pg
+	 plan_file = sqitch.plan
+	 top_dir = .

--- a/psql_schemas/sqitch.plan
+++ b/psql_schemas/sqitch.plan
@@ -1,0 +1,10 @@
+%syntax-version=1.0.0
+%project=meatPacker
+
+size_units 2018-01-14T05:28:00Z Zac Slade,,, <krakrjak@zombiebits> # Add unit type enum for byte sizes
+transfer_units 2018-01-14T05:32:13Z Zac Slade,,, <krakrjak@zombiebits> # Add Hz units to schema
+cycle_units 2018-01-14T06:47:57Z Zac Slade,,, <krakrjak@zombiebits> # Add cycle units
+computers 2018-01-14T04:43:29Z Zac Slade,,, <krakrjak@zombiebits> # Add initial table template
+drives [computers size_units] 2018-01-14T04:44:15Z Zac Slade,,, <krakrjak@zombiebits> # Add disk drive table
+memory [computers size_units transfer_units] 2018-01-14T04:44:54Z Zac Slade,,, <krakrjak@zombiebits> # Add memory stick table
+cpus [computers cycle_units] 2018-01-14T04:45:21Z Zac Slade,,, <krakrjak@zombiebits> # Add cpu tracking table

--- a/psql_schemas/verify/computers.sql
+++ b/psql_schemas/verify/computers.sql
@@ -1,0 +1,9 @@
+-- Verify meatPacker:computers on pg
+
+BEGIN;
+
+select computer_id, os, motherboard_model, motherboard_sn, barcode
+  from computers
+ where FALSE;
+
+ROLLBACK;

--- a/psql_schemas/verify/cpus.sql
+++ b/psql_schemas/verify/cpus.sql
@@ -1,0 +1,9 @@
+-- Verify meatPacker:cpus on pg
+
+BEGIN;
+
+select computer_id, model, core_count, threads_per_core, speed, speed_unit
+  from cpus
+ where FALSE;
+
+ROLLBACK;

--- a/psql_schemas/verify/cycle_units.sql
+++ b/psql_schemas/verify/cycle_units.sql
@@ -1,0 +1,7 @@
+-- Verify meatPacker:cycle_units on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;

--- a/psql_schemas/verify/drives.sql
+++ b/psql_schemas/verify/drives.sql
@@ -1,0 +1,30 @@
+-- Verify meatPacker:drives on pg
+
+BEGIN;
+
+-- Check for drive_types enum first
+select exists (
+    select enum_range(NULL::drive_types)
+);
+
+-- Spinning rust is the lowest possible state
+select 'HDD' :: drive_types = 'HDD' :: drive_types;
+select 'HDD' :: drive_types < 'SSD' :: drive_types;
+select 'HDD' :: drive_types < 'NVME' :: drive_types;
+
+-- Solid state drives are nice
+select 'SSD' :: drive_types > 'HDD' :: drive_types;
+select 'SSD' :: drive_types = 'SSD' :: drive_types;
+select 'SSD' :: drive_types < 'NVME' :: drive_types;
+
+-- NVME is the bees knees today
+select 'NVME' :: drive_types > 'HDD' :: drive_types;
+select 'NVME' :: drive_types > 'SSD' :: drive_types;
+select 'NVME' :: drive_types = 'NVME' :: drive_types;
+
+--Check that the required columns are a part of the table
+select computer_id, model, drive_size, size_unit, drive_type, sn
+  from drives
+ where FALSE;
+
+ROLLBACK;

--- a/psql_schemas/verify/memory.sql
+++ b/psql_schemas/verify/memory.sql
@@ -1,0 +1,33 @@
+-- Verify meatPacker:memory on pg
+
+BEGIN;
+
+select exists (
+    select enum_range(NULL::memory_types)
+);
+
+select 'DDR' :: memory_types = 'DDR' :: memory_types;
+select 'DDR' :: memory_types < 'DDR2' :: memory_types;
+select 'DDR' :: memory_types < 'DDR3' :: memory_types;
+select 'DDR' :: memory_types < 'DDR4' :: memory_types;
+
+select 'DDR2' :: memory_types > 'DDR' :: memory_types;
+select 'DDR2' :: memory_types = 'DDR2' :: memory_types;
+select 'DDR2' :: memory_types < 'DDR3' :: memory_types;
+select 'DDR2' :: memory_types < 'DDR4' :: memory_types;
+
+select 'DDR3' :: memory_types > 'DDR' :: memory_types;
+select 'DDR3' :: memory_types > 'DDR2' :: memory_types;
+select 'DDR3' :: memory_types = 'DDR3' :: memory_types;
+select 'DDR3' :: memory_types < 'DDR4' :: memory_types;
+
+select 'DDR4' :: memory_types > 'DDR' :: memory_types;
+select 'DDR4' :: memory_types > 'DDR2' :: memory_types;
+select 'DDR4' :: memory_types > 'DDR3' :: memory_types;
+select 'DDR4' :: memory_types = 'DDR4' :: memory_types;
+
+select computer_id, model, mem_speed, speed_unit, mem_size, size_unit, mem_type
+  from memory
+ where FALSE;
+
+ROLLBACK;

--- a/psql_schemas/verify/size_units.sql
+++ b/psql_schemas/verify/size_units.sql
@@ -1,0 +1,60 @@
+-- Verify meatPacker:size_units on pg
+
+BEGIN;
+
+-- Does our enum exist?
+select exists (
+    select enum_range(NULL::size_units)
+);
+
+-- Does the ordering make sense?
+
+-- Bytes are smallest
+select 'B' :: size_units = 'B'::size_units;
+select 'B' :: size_units < 'KB'::size_units;
+select 'B' :: size_units < 'MB'::size_units;
+select 'B' :: size_units < 'GB'::size_units;
+select 'B' :: size_units < 'TB'::size_units;
+select 'B' :: size_units < 'PB'::size_units;
+
+-- Kilo Bytes are the next smallest
+select 'KB' :: size_units > 'B'::size_units;
+select 'KB' :: size_units = 'KB'::size_units;
+select 'KB' :: size_units < 'MB'::size_units;
+select 'KB' :: size_units < 'GB'::size_units;
+select 'KB' :: size_units < 'TB'::size_units;
+select 'KB' :: size_units < 'PB'::size_units;
+
+-- Mega Bytes are the next smallest
+select 'MB' :: size_units > 'B'::size_units;
+select 'MB' :: size_units > 'KB'::size_units;
+select 'MB' :: size_units = 'MB'::size_units;
+select 'MB' :: size_units < 'GB'::size_units;
+select 'MB' :: size_units < 'TB'::size_units;
+select 'MB' :: size_units < 'PB'::size_units;
+
+-- Giga Bytes are the next smallest
+select 'GB' :: size_units > 'B'::size_units;
+select 'GB' :: size_units > 'KB'::size_units;
+select 'GB' :: size_units > 'MB'::size_units;
+select 'GB' :: size_units = 'GB'::size_units;
+select 'GB' :: size_units < 'TB'::size_units;
+select 'GB' :: size_units < 'PB'::size_units;
+
+-- Tera Bytes are the next smallest
+select 'TB' :: size_units > 'B'::size_units;
+select 'TB' :: size_units > 'KB'::size_units;
+select 'TB' :: size_units > 'MB'::size_units;
+select 'TB' :: size_units > 'GB'::size_units;
+select 'TB' :: size_units = 'TB'::size_units;
+select 'TB' :: size_units < 'PB'::size_units;
+
+-- Peta Bytes are the next smallest
+select 'PB' :: size_units > 'B'::size_units;
+select 'PB' :: size_units > 'KB'::size_units;
+select 'PB' :: size_units > 'MB'::size_units;
+select 'PB' :: size_units > 'GB'::size_units;
+select 'PB' :: size_units > 'TB'::size_units;
+select 'PB' :: size_units = 'PB'::size_units;
+
+ROLLBACK;

--- a/psql_schemas/verify/transfer_units.sql
+++ b/psql_schemas/verify/transfer_units.sql
@@ -1,0 +1,53 @@
+-- Verify meatPacker:transfer_units on pg
+
+BEGIN;
+
+select exists (
+    select enum_range(NULL::transfer_units)
+);
+
+-- Make sure ordering is sane
+
+select 'T/s' :: transfer_units = 'T/s' :: transfer_units;
+select 'T/s' :: transfer_units < 'KT/s' :: transfer_units;
+select 'T/s' :: transfer_units < 'MT/s' :: transfer_units;
+select 'T/s' :: transfer_units < 'GT/s' :: transfer_units;
+select 'T/s' :: transfer_units < 'TT/s' :: transfer_units;
+select 'T/s' :: transfer_units < 'PT/s' :: transfer_units;
+
+select 'KT/s' :: transfer_units > 'T/s' :: transfer_units;
+select 'KT/s' :: transfer_units = 'KT/s' :: transfer_units;
+select 'KT/s' :: transfer_units < 'MT/s' :: transfer_units;
+select 'KT/s' :: transfer_units < 'GT/s' :: transfer_units;
+select 'KT/s' :: transfer_units < 'TT/s' :: transfer_units;
+select 'KT/s' :: transfer_units < 'PT/s' :: transfer_units;
+
+select 'MT/s' :: transfer_units > 'T/s' :: transfer_units;
+select 'MT/s' :: transfer_units > 'KT/s' :: transfer_units;
+select 'MT/s' :: transfer_units = 'MT/s' :: transfer_units;
+select 'MT/s' :: transfer_units < 'GT/s' :: transfer_units;
+select 'MT/s' :: transfer_units < 'TT/s' :: transfer_units;
+select 'MT/s' :: transfer_units < 'PT/s' :: transfer_units;
+
+select 'GT/s' :: transfer_units > 'T/s' :: transfer_units;
+select 'GT/s' :: transfer_units > 'KT/s' :: transfer_units;
+select 'GT/s' :: transfer_units > 'MT/s' :: transfer_units;
+select 'GT/s' :: transfer_units = 'GT/s' :: transfer_units;
+select 'GT/s' :: transfer_units < 'TT/s' :: transfer_units;
+select 'GT/s' :: transfer_units < 'PT/s' :: transfer_units;
+
+select 'TT/s' :: transfer_units > 'T/s' :: transfer_units;
+select 'TT/s' :: transfer_units > 'KT/s' :: transfer_units;
+select 'TT/s' :: transfer_units > 'MT/s' :: transfer_units;
+select 'TT/s' :: transfer_units > 'GT/s' :: transfer_units;
+select 'TT/s' :: transfer_units = 'TT/s' :: transfer_units;
+select 'TT/s' :: transfer_units < 'PT/s' :: transfer_units;
+
+select 'PT/s' :: transfer_units > 'T/s' :: transfer_units;
+select 'PT/s' :: transfer_units > 'KT/s' :: transfer_units;
+select 'PT/s' :: transfer_units > 'MT/s' :: transfer_units;
+select 'PT/s' :: transfer_units > 'GT/s' :: transfer_units;
+select 'PT/s' :: transfer_units > 'TT/s' :: transfer_units;
+select 'PT/s' :: transfer_units = 'PT/s' :: transfer_units;
+
+ROLLBACK;


### PR DESCRIPTION
  * schemas are managed with sqitch, use `sqitch deploy` and `sqitch
verify` to validate the schema. To revert the schema use `sqitch
revert`.

  * Creates three data types for four tables. Datatypes are related to
units such as, Hz, Kilobytes, and T/s. Tables are computers, cpus,
drives, and memory.